### PR TITLE
chore: add .tmp files to .gitignore (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+*.tmp


### PR DESCRIPTION
### Description

This pull request adds a rule to the `.gitignore` file to exclude `.tmp` files from version control.

### Why

Temporary `.tmp` files are often generated by text editors or build tools, and should not be committed to the repository.

### Related Issue

Closes #29 
