### PR TITLE
Add Outbox Pattern level with toggle-based failure/success flow (Issue #45)

### DIFF
--- a/Scenes/outboxPattern.tscn
+++ b/Scenes/outboxPattern.tscn
@@ -1,0 +1,135 @@
+[gd_scene load_steps=12 format=3 uid="uid://uniqoutbox123"]
+
+[ext_resource type="Texture2D" uid="uid://dlnjpu1sbekqf" path="res://2D Assets/conveyer texture.png" id="1_7bjaj"]
+[ext_resource type="Script" path="res://Scripts/conveyor.gd" id="2_etah7"]
+[ext_resource type="PackedScene" uid="uid://whu4rwgsyl8u" path="res://Scenes/sink.tscn" id="3_y5n06"]
+[ext_resource type="PackedScene" uid="uid://p2kk0a6bpmai" path="res://Scenes/event_box.tscn" id="4_fjrb2"]
+[ext_resource type="PackedScene" uid="uid://cg1qlr4r42xs6" path="res://Scenes/box_b.tscn" id="5_5su6q"]
+[ext_resource type="Script" path="res://Scripts/event_button.gd" id="6_xyb5q"]
+[ext_resource type="Script" path="res://Scripts/restart.gd" id="7_3f2sq"]
+[ext_resource type="Texture2D" uid="uid://crbbdu26tlg2k" path="res://2D Assets/background.png" id="8_lhevx"]
+[ext_resource type="Script" path="res://Scripts/outboxPattern.gd" id="9_outbox"]
+[ext_resource type="Texture2D" uid="uid://cjn14twvcwa8y" path="res://2D Assets/boxes/blueBox.png" id="10_bluebox"]
+
+[node name="outboxPattern" type="Node2D"]
+script = ExtResource("9_outbox")
+
+[node name="Panel" type="Panel" parent="."]
+z_index = -2
+mouse_filter = 2
+
+[node name="TextureRect" type="TextureRect" parent="Panel"]
+layout_mode = 0
+offset_right = 1920.0
+offset_bottom = 1080.0
+scale = Vector2(0.65, 0.65)
+texture = ExtResource("8_lhevx")
+
+[node name="Conveyor" type="Line2D" parent="."]
+texture_repeat = 2
+points = PackedVector2Array(0, 0, 0, 0)
+width = 100.0
+texture = ExtResource("1_7bjaj")
+texture_mode = 1
+script = ExtResource("2_etah7")
+
+[node name="Sink" parent="." instance=ExtResource("3_y5n06")]
+position = Vector2(558, 550)
+scale = Vector2(0.7, 0.7)
+
+[node name="BoxA" parent="." instance=ExtResource("4_fjrb2")]
+position = Vector2(558, 88)
+scale = Vector2(0.698225, 0.698225)
+
+[node name="OutboxNode" type="Node2D" parent="."]
+position = Vector2(558, 300)
+
+[node name="Sprite2D" type="Sprite2D" parent="OutboxNode"]
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("10_bluebox")
+
+[node name="Label" type="RichTextLabel" parent="OutboxNode"]
+offset_left = -33.0
+offset_top = -63.0
+offset_right = 153.0
+offset_bottom = -23.0
+text = "Outbox Table"
+mouse_filter = 2
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 893.0
+offset_top = 398.0
+offset_right = 933.0
+offset_bottom = 438.0
+scale = Vector2(0.7, 0.7)
+script = ExtResource("6_xyb5q")
+
+[node name="Button" type="Button" parent="Control"]
+layout_mode = 0
+offset_right = 342.0
+offset_bottom = 132.0
+
+[node name="RichTextLabel" type="RichTextLabel" parent="Control/Button"]
+layout_mode = 0
+offset_top = 37.0
+offset_right = 338.0
+offset_bottom = 110.0
+mouse_filter = 2
+theme_override_font_sizes/normal_font_size = 50
+bbcode_enabled = true
+text = "[center]START"
+
+[node name="Control_Toggle" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 1200.0
+offset_top = 398.0
+offset_right = 1240.0
+offset_bottom = 438.0
+scale = Vector2(0.7, 0.7)
+
+[node name="Button" type="Button" parent="Control_Toggle"]
+layout_mode = 0
+offset_right = 342.0
+offset_bottom = 132.0
+
+[node name="RichTextLabel" type="RichTextLabel" parent="Control_Toggle/Button"]
+layout_mode = 0
+offset_top = 37.0
+offset_right = 338.0
+offset_bottom = 110.0
+mouse_filter = 2
+theme_override_font_sizes/normal_font_size = 40
+bbcode_enabled = true
+text = "[center]Outbox: OFF"
+
+[node name="Control2" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_left = 893.0
+offset_top = 517.0
+offset_right = 933.0
+offset_bottom = 557.0
+scale = Vector2(0.7, 0.7)
+script = ExtResource("7_3f2sq")
+
+[node name="Button" type="Button" parent="Control2"]
+layout_mode = 0
+offset_right = 342.0
+offset_bottom = 132.0
+
+[node name="RichTextLabel" type="RichTextLabel" parent="Control2/Button"]
+layout_mode = 0
+offset_top = 37.0
+offset_right = 338.0
+offset_bottom = 110.0
+mouse_filter = 2
+theme_override_font_sizes/normal_font_size = 50
+bbcode_enabled = true
+text = "[center]RESTART"
+
+[connection signal="pressed" from="Control/Button" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="Control_Toggle/Button" to="." method="_on_toggle_button_pressed"]
+[connection signal="pressed" from="Control2/Button" to="Control2" method="_on_button_pressed"]

--- a/Scripts/level.gd
+++ b/Scripts/level.gd
@@ -1,12 +1,12 @@
 extends Node
-var sinkBoxMatchNeeded=[false,true,true,false]
+var sinkBoxMatchNeeded=[false,true,true,false,false]
 var sinkBoxMatchPresent
 var sinkUsed
-var dlsRequired=[false,false,false,true]
+var dlsRequired=[false,false,false,true,false]
 var dlsUsed
 var totalbox=[2,2,3]
 var nextLevel
-var levels=["basicEventFlow","boxClick","multiSink","dlqPattern"]
+var levels=["basicEventFlow","boxClick","multiSink","dlqPattern","outboxPattern"]
 var levelind=0
 
 func initialise():

--- a/Scripts/outboxPattern.gd
+++ b/Scripts/outboxPattern.gd
@@ -1,0 +1,100 @@
+extends Node2D
+
+@onready var sink = $Sink
+@onready var outbox_node = $OutboxNode
+@onready var toggle_button = $Control_Toggle/Button
+@onready var toggle_label = $Control_Toggle/Button/RichTextLabel
+@onready var outbox_visual = $OutboxNode/Sprite2D
+
+var outbox_enabled = false
+var events = []
+
+func _ready() -> void:
+	# Disable default conveyer controller to handle movement manually
+	ConveyerController.can_send = false
+	update_outbox_visual()
+	
+	# Update toggle text
+	if toggle_label:
+		toggle_label.text = "[center]Outbox: OFF"
+
+func update_outbox_visual():
+	if outbox_visual:
+		if outbox_enabled:
+			outbox_visual.modulate = Color(1, 1, 1, 1) # Full opacity
+		else:
+			outbox_visual.modulate = Color(0.5, 0.5, 0.5, 0.5) # Dimmed
+
+func _on_toggle_button_pressed() -> void:
+	outbox_enabled = !outbox_enabled
+	update_outbox_visual()
+	if toggle_label:
+		if outbox_enabled:
+			toggle_label.text = "[center]Outbox: ON"
+		else:
+			toggle_label.text = "[center]Outbox: OFF"
+
+func _on_start_button_pressed() -> void:
+	print("custom start pressed")
+	Level.initialise()
+	
+	# Capture events
+	events = ConveyerController.events.duplicate()
+	
+	if outbox_enabled:
+		start_success_flow()
+	else:
+		start_failure_flow()
+
+func start_failure_flow():
+	print("Starting failure flow")
+	for event in events:
+		if event == null or not is_instance_valid(event): continue
+		event.sending = true
+		
+		var tween = get_tree().create_tween()
+		# Move halfway to sink
+		var mid_point = (event.position + sink.position) / 2
+		tween.tween_property(event, "position", mid_point, 1.0)
+		await tween.finished
+		
+		# Fade out
+		var tween_fail = get_tree().create_tween()
+		tween_fail.tween_property(event, "modulate:a", 0.0, 0.5)
+		await tween_fail.finished
+		event.visible = false
+		
+	# Show failure message
+	var message_display = preload("res://Scenes/message_display.tscn").instantiate()
+	add_child(message_display)
+	message_display.show_message("Data Loss! Enable Outbox.")
+	await message_display.show_message_for_duration(2.0)
+	message_display.queue_free()
+	
+	Level.next_level()
+
+func start_success_flow():
+	print("Starting success flow")
+	# First move to Outbox
+	for event in events:
+		if event == null or not is_instance_valid(event): continue
+		event.sending = true
+		
+		var tween = get_tree().create_tween()
+		tween.tween_property(event, "position", outbox_node.position, 1.0)
+		await tween.finished
+		
+	# Store simulation
+	await get_tree().create_timer(0.5).timeout
+	
+	# Then move to Sink
+	for event in events:
+		if event == null or not is_instance_valid(event): continue
+		
+		var tween2 = get_tree().create_tween()
+		tween2.tween_property(event, "position", sink.position, 1.0)
+		await tween2.finished
+		
+	# Wait for sink detection logic (usually Area2D signal in Sink)
+	await get_tree().create_timer(1.0).timeout
+	Level.next_level()


### PR DESCRIPTION
This PR implements a new educational level for the Outbox Pattern, resolving issue #45.

Changes included:

- Added a new scene: `Scenes/outboxPattern.tscn`
  - Introduces a visual "Outbox Table" (blue box)
  - Provides a toggle button to enable/disable the Outbox mechanism
  - Keeps UI consistent with existing levels (Start / Restart pattern)

- Added new logic: `Scripts/outboxPattern.gd`
  - Overrides default conveyor behavior for this level
  - When Outbox is OFF:
    - Events move toward the Sink and are lost (fade out), simulating data loss
  - When Outbox is ON:
    - Events are first routed to the Outbox node
    - After a short delay, they are reliably forwarded to the Sink
  - This allows players to directly compare failure vs. reliable delivery

- Updated `Scripts/level.gd`
  - Registered `outboxPattern` in the level rotation
  - Extended `sinkBoxMatchNeeded` and `dlsRequired` arrays accordingly

Implementation notes:
- All changes are scoped strictly to this issue.
- A new branch (`issue-45-outbox-pattern`) was created.
- Commits are DCO signed (`--signoff`).
- No unrelated files or behavior were modified.

The new level appears after the DLQ Pattern level and is ready for review and playtesting.
