### PR TITLE
feat: Add sink availability indicator with blinking light

### DIFF
--- a/Scenes/sink.tscn
+++ b/Scenes/sink.tscn
@@ -32,6 +32,7 @@ offset_left = -25.0
 offset_top = -25.0
 offset_right = 25.0
 offset_bottom = 25.0
+mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_circle")
 
 [connection signal="area_entered" from="Area2D" to="Area2D" method="_on_area_entered"]

--- a/Scripts/sink.gd
+++ b/Scripts/sink.gd
@@ -2,15 +2,11 @@ extends Sprite2D
 
 @export var expectedType: String
 
-var _available := true
-
 @export var available: bool = true:
 	set(value):
-		_available = value
+		available = value
 		if indicator_light:
 			indicator_light.visible = value
-	get:
-		return _available
 
 @onready var indicator_light: Control = $IndicatorLight
 
@@ -21,4 +17,4 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	if available and indicator_light:
 		var time = Time.get_ticks_msec() / 200.0
-		indicator_light.modulate.a = 0.6 + sin(time) * 0.4
+		indicator_light.modulate.a = 0.6 + (sin(time) * 0.4)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :gift: Added available export variable to `Scripts/sink.gd` to control sink status (defaults to true).
- :gift: Added a visual IndicatorLight (centered green circle) to `Scenes/sink.tscn`.
- :gift: Implemented a blinking animation in _process that activates only when the sink is available.
- :bug: Set mouse_filter = 2 (Ignore) on the indicator light so it does not block mouse clicks on the sink.
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #65

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Added a blinking green indicator light to sinks to visually represent their availability status.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
