### PR TITLE
feat: Add sink availability indicator with blinking light

### DIFF
--- a/Scenes/sink.tscn
+++ b/Scenes/sink.tscn
@@ -20,4 +20,12 @@ script = ExtResource("2_16xt0")
 position = Vector2(0, -5.83331)
 shape = SubResource("RectangleShape2D_7l3ci")
 
+[node name="IndicatorLight" type="ColorRect" parent="."]
+offset_left = -10.0
+offset_top = -220.0
+offset_right = 10.0
+offset_bottom = -200.0
+color = Color(0, 1, 0, 1)
+z_index = 1
+
 [connection signal="area_entered" from="Area2D" to="Area2D" method="_on_area_entered"]

--- a/Scripts/sink.gd
+++ b/Scripts/sink.gd
@@ -1,13 +1,27 @@
 extends Sprite2D
 
 @export var expectedType: String
+@export var available: bool = true
+
+var blink_timer: float = 0.0
+var blink_interval: float = 0.5
+var indicator_light: ColorRect = null
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	indicator_light = get_node_or_null("IndicatorLight")
+	if indicator_light == null:
+		push_warning("IndicatorLight not found in sink scene")
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
-	pass
+	if indicator_light != null:
+		if available:
+			blink_timer += delta
+			if blink_timer >= blink_interval:
+				blink_timer = 0.0
+				indicator_light.visible = !indicator_light.visible
+		else:
+			indicator_light.visible = false


### PR DESCRIPTION
## Summary
Adds a visual availability indicator to sinks - a green blinking light that shows when a sink is operational.

## Changes
- Added `available` export variable to [Scripts/sink.gd](cci:7://file:///e:/go/src/knative.dev/educational-game/Scripts/sink.gd:0:0-0:0) (defaults to `true`)
- Added green indicator light (ColorRect) to [Scenes/sink.tscn](cci:7://file:///e:/go/src/knative.dev/educational-game/Scenes/sink.tscn:0:0-0:0)
- Implemented blinking animation (0.5s interval)
- Light turns off when `available = false`

## Testing
Tested in Godot 4.3 - light blinks continuously when available and turns off when unavailable.
