### PR TITLE
feat: disable START button until route is connected

### DIFF
--- a/Scripts/SinkClick.gd
+++ b/Scripts/SinkClick.gd
@@ -8,6 +8,11 @@ func on_click():
 	print("hey")
 	ConveyerController.destination.append(get_parent().get_position())
 	transfer_box()
+	
+	# Enable START button now that a route is connected
+	var start_button = get_tree().get_root().find_child("Control", true, false)
+	if start_button and start_button.has_method("enable_start"):
+		start_button.enable_start()
 
 func transfer_box():
 	print("sending")

--- a/Scripts/event_button.gd
+++ b/Scripts/event_button.gd
@@ -1,15 +1,22 @@
 extends Control
 
+@onready var button = $Button
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	pass # Replace with function body.
+	# Disable START button initially - needs route to be connected first
+	button.disabled = true
+	button.modulate = Color(0.5, 0.5, 0.5, 1.0)  # Gray out when disabled
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	pass
 
+# Called by SinkClick when a route is connected
+func enable_start() -> void:
+	button.disabled = false
+	button.modulate = Color(1.0, 1.0, 1.0, 1.0)  # Normal color when enabled
 
 func _on_button_pressed() -> void:
 	Level.initialise()


### PR DESCRIPTION
## Summary
Disables the START button until the player connects a box to a sink.

## Changes
- `event_button.gd`: Button starts disabled and grayed out, added `enable_start()` function
- `SinkClick.gd`: Calls `enable_start()` when a route is connected

## Behavior
1. Game starts → START button is disabled (grayed out)
2. Player clicks box → clicks sink → route connected
3. START button becomes enabled (normal color)
4. Player can now click START

Closes #97 