### PR TITLE
Replacing local draggable_filter scene with saved scene of  draggable_filter

### DIFF
--- a/Scenes/boxClick.tscn
+++ b/Scenes/boxClick.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://c8lin6dur1umi"]
+[gd_scene load_steps=11 format=3 uid="uid://c8lin6dur1umi"]
 
 [ext_resource type="Texture2D" uid="uid://crbbdu26tlg2k" path="res://2D Assets/background.png" id="1_fdm6s"]
 [ext_resource type="Texture2D" uid="uid://dlnjpu1sbekqf" path="res://2D Assets/conveyer texture.png" id="2_ocbiy"]
@@ -7,32 +7,9 @@
 [ext_resource type="PackedScene" uid="uid://p2kk0a6bpmai" path="res://Scenes/event_box.tscn" id="6_gdfin"]
 [ext_resource type="PackedScene" uid="uid://cg1qlr4r42xs6" path="res://Scenes/box_b.tscn" id="7_j7uju"]
 [ext_resource type="Script" path="res://Scripts/event_button.gd" id="9_va8kg"]
+[ext_resource type="PackedScene" uid="uid://bquha0225l1ju" path="res://Scenes/draggable_filter_blue.tscn" id="9_wshn7"]
+[ext_resource type="PackedScene" uid="uid://bi4a6dl8q6rnj" path="res://Scenes/draggable_filter_red.tscn" id="10_d1jj7"]
 [ext_resource type="Script" path="res://Scripts/restart.gd" id="10_rwca5"]
-[ext_resource type="Texture2D" uid="uid://cs6prh1shv4bh" path="res://2D Assets/funnels/blueFunnel.png" id="10_w4xqm"]
-[ext_resource type="Script" path="res://Scripts/draggable_filter.gd" id="10_xwwl6"]
-[ext_resource type="Texture2D" uid="uid://bpkn0kgyf867u" path="res://2D Assets/funnels/redFunnel.png" id="11_2hn41"]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_e8kq8"]
-size = Vector2(160, 185)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qgft8"]
-bg_color = Color(0.262745, 0.545098, 0.8, 1)
-border_width_top = 7
-border_color = Color(0.254902, 0.537255, 0.792157, 1)
-corner_radius_top_left = 7
-corner_radius_top_right = 7
-corner_radius_bottom_right = 7
-corner_radius_bottom_left = 7
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tqu56"]
-bg_color = Color(1, 0.423529, 0.47451, 1)
-border_width_top = 9
-border_width_bottom = 4
-border_color = Color(1, 0.431373, 0.482353, 1)
-corner_radius_top_left = 7
-corner_radius_top_right = 7
-corner_radius_bottom_right = 7
-corner_radius_bottom_left = 7
 
 [node name="base" type="Node2D"]
 scale = Vector2(0.6, 0.6)
@@ -109,61 +86,11 @@ theme_override_font_sizes/normal_font_size = 50
 bbcode_enabled = true
 text = "[center]RESTART"
 
-[node name="Draggable Filter" type="Area2D" parent="."]
-position = Vector2(288.333, 205)
-script = ExtResource("10_xwwl6")
-filterColor = "Blue"
+[node name="Draggable Filter3" parent="." instance=ExtResource("9_wshn7")]
+position = Vector2(283.333, 205)
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Draggable Filter"]
-position = Vector2(0.333374, -0.5)
-shape = SubResource("RectangleShape2D_e8kq8")
-
-[node name="Sprite2D" type="Sprite2D" parent="Draggable Filter"]
-position = Vector2(0.333374, 0.333313)
-texture = ExtResource("10_w4xqm")
-
-[node name="hoverlabel" type="RichTextLabel" parent="Draggable Filter"]
-visible = false
-offset_left = 73.3336
-offset_top = -110.0
-offset_right = 178.334
-offset_bottom = -70.0
-theme_override_styles/normal = SubResource("StyleBoxFlat_qgft8")
-bbcode_enabled = true
-text = "[center] [b]FILTER B
-"
-
-[node name="Draggable Filter2" type="Area2D" parent="."]
-position = Vector2(286.667, 431.667)
-script = ExtResource("10_xwwl6")
-filterColor = "Red"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Draggable Filter2"]
-position = Vector2(0.333374, -0.5)
-shape = SubResource("RectangleShape2D_e8kq8")
-
-[node name="Sprite2D" type="Sprite2D" parent="Draggable Filter2"]
-position = Vector2(0.333374, 0.333313)
-texture = ExtResource("11_2hn41")
-
-[node name="hoverlabel" type="RichTextLabel" parent="Draggable Filter2"]
-visible = false
-offset_left = 74.9997
-offset_top = -120.0
-offset_right = 182.0
-offset_bottom = -74.0004
-theme_override_styles/normal = SubResource("StyleBoxFlat_tqu56")
-bbcode_enabled = true
-text = "[center][b]FILTER R
-"
+[node name="Draggable Filter" parent="." instance=ExtResource("10_d1jj7")]
+position = Vector2(278.333, 418.333)
 
 [connection signal="pressed" from="Control/Button" to="Control" method="_on_button_pressed"]
 [connection signal="pressed" from="Control2/Button" to="Control2" method="_on_button_pressed"]
-[connection signal="area_entered" from="Draggable Filter" to="Draggable Filter" method="_on_area_entered"]
-[connection signal="body_shape_exited" from="Draggable Filter" to="Draggable Filter" method="_on_body_shape_exited"]
-[connection signal="mouse_entered" from="Draggable Filter" to="Draggable Filter" method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="Draggable Filter" to="Draggable Filter" method="_on_mouse_exited"]
-[connection signal="area_entered" from="Draggable Filter2" to="Draggable Filter2" method="_on_area_entered"]
-[connection signal="body_shape_exited" from="Draggable Filter2" to="Draggable Filter2" method="_on_body_shape_exited"]
-[connection signal="mouse_entered" from="Draggable Filter2" to="Draggable Filter2" method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="Draggable Filter2" to="Draggable Filter2" method="_on_mouse_exited"]

--- a/Scenes/draggable_filter_blue.tscn
+++ b/Scenes/draggable_filter_blue.tscn
@@ -29,7 +29,8 @@ shape = SubResource("RectangleShape2D_e8kq8")
 position = Vector2(0.333374, 0.333313)
 texture = ExtResource("2_bv34i")
 
-[node name="RichTextLabel" type="RichTextLabel" parent="."]
+[node name="hoverlabel" type="RichTextLabel" parent="."]
+visible = false
 offset_left = 71.667
 offset_top = -118.0
 offset_right = 178.667

--- a/Scenes/draggable_filter_red.tscn
+++ b/Scenes/draggable_filter_red.tscn
@@ -29,7 +29,7 @@ shape = SubResource("RectangleShape2D_e8kq8")
 position = Vector2(0.333374, 0.333313)
 texture = ExtResource("2_vef61")
 
-[node name="RichTextLabel" type="RichTextLabel" parent="."]
+[node name="hoverlabel" type="RichTextLabel" parent="."]
 visible = false
 offset_left = 70.667
 offset_top = -114.0

--- a/Scenes/multiSink.tscn
+++ b/Scenes/multiSink.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://drhixkbg1n4sa"]
+[gd_scene load_steps=19 format=3 uid="uid://drhixkbg1n4sa"]
 
 [ext_resource type="Script" path="res://Scripts/multi_sink.gd" id="1_x4ymc"]
 [ext_resource type="Texture2D" uid="uid://crbbdu26tlg2k" path="res://2D Assets/background.png" id="1_x35ji"]
@@ -10,8 +10,6 @@
 [ext_resource type="Texture2D" uid="uid://bdn2dphqbqnhh" path="res://2D Assets/boxes/greenBox.png" id="7_ddj2a"]
 [ext_resource type="Texture2D" uid="uid://dlnjpu1sbekqf" path="res://2D Assets/conveyer texture.png" id="8_wibrt"]
 [ext_resource type="Script" path="res://Scripts/conveyor.gd" id="9_s7axg"]
-[ext_resource type="Script" path="res://Scripts/draggable_filter.gd" id="10_oh2sn"]
-[ext_resource type="Texture2D" uid="uid://dreyprum5m05y" path="res://2D Assets/funnels/greenFunnel.png" id="13_fp6xy"]
 [ext_resource type="PackedScene" uid="uid://bquha0225l1ju" path="res://Scenes/draggable_filter_blue.tscn" id="13_w7pdg"]
 [ext_resource type="Script" path="res://Scripts/multi_sink_start.gd" id="15_2dg66"]
 [ext_resource type="Script" path="res://Scripts/restart.gd" id="15_hhntj"]
@@ -35,16 +33,18 @@ corner_radius_top_right = 7
 corner_radius_bottom_right = 7
 corner_radius_bottom_left = 7
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_o1j7t"]
-size = Vector2(160, 185)
+[sub_resource type="CompressedTexture2D" id="CompressedTexture2D_ibnru"]
+load_path = "res://.godot/imported/greenFunnel.png-9b31229a6ae861714dea240c0b8a6cd6.ctex"
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4cu8a"]
-content_margin_top = 8.0
-bg_color = Color(0.309804, 0.552941, 0.203922, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0ulyt"]
+bg_color = Color(0.47451, 0.701961, 0.376471, 1)
+border_width_top = 9
+border_width_bottom = 4
+border_color = Color(0.47451, 0.701961, 0.376471, 1)
+corner_radius_top_left = 7
+corner_radius_top_right = 7
+corner_radius_bottom_right = 7
+corner_radius_bottom_left = 7
 
 [node name="multiSink" type="Node2D"]
 script = ExtResource("1_x4ymc")
@@ -129,31 +129,6 @@ scale = Vector2(0.7, 0.7)
 [node name="CollisionShape2D" parent="Draggable Filter4" index="0"]
 scale = Vector2(0.6, 0.6)
 
-[node name="Draggable Filter3" type="Area2D" parent="."]
-position = Vector2(78, 349)
-scale = Vector2(0.7, 0.7)
-script = ExtResource("10_oh2sn")
-filterColor = "Green"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Draggable Filter3"]
-position = Vector2(0.333374, -0.5)
-scale = Vector2(0.6, 0.6)
-shape = SubResource("RectangleShape2D_o1j7t")
-
-[node name="Sprite2D" type="Sprite2D" parent="Draggable Filter3"]
-position = Vector2(0.333374, 0.333313)
-texture = ExtResource("13_fp6xy")
-
-[node name="hoverlabel" type="RichTextLabel" parent="Draggable Filter3"]
-visible = false
-offset_left = 85.7143
-offset_top = -85.7143
-offset_right = 187.714
-offset_bottom = -45.7143
-theme_override_styles/normal = SubResource("StyleBoxFlat_4cu8a")
-bbcode_enabled = true
-text = "[center] [b]FILTER G"
-
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 0
@@ -214,10 +189,22 @@ filterColor = "Red"
 [node name="CollisionShape2D" parent="Draggable Filter5" index="0"]
 scale = Vector2(0.6, 0.6)
 
-[connection signal="area_entered" from="Draggable Filter3" to="Draggable Filter3" method="_on_area_entered"]
-[connection signal="body_shape_exited" from="Draggable Filter3" to="Draggable Filter3" method="_on_body_shape_exited"]
-[connection signal="mouse_entered" from="Draggable Filter3" to="Draggable Filter3" method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="Draggable Filter3" to="Draggable Filter3" method="_on_mouse_exited"]
+[node name="Draggable Filter" parent="." instance=ExtResource("13_w7pdg")]
+position = Vector2(77, 349)
+scale = Vector2(0.7, 0.7)
+filterColor = "Green"
+
+[node name="CollisionShape2D" parent="Draggable Filter" index="0"]
+scale = Vector2(0.6, 0.6)
+
+[node name="Sprite2D" parent="Draggable Filter" index="1"]
+texture = SubResource("CompressedTexture2D_ibnru")
+
+[node name="hoverlabel" parent="Draggable Filter" index="2"]
+theme_override_styles/normal = SubResource("StyleBoxFlat_0ulyt")
+text = "[center][b]FILTER G
+"
+
 [connection signal="pressed" from="Control/Button" to="." method="_on_button_pressed"]
 [connection signal="pressed" from="Control/Button" to="Control" method="_on_button_pressed"]
 [connection signal="pressed" from="Control2/Button" to="Control2" method="_on_button_pressed"]
@@ -226,3 +213,4 @@ scale = Vector2(0.6, 0.6)
 [editable path="SinkG"]
 [editable path="Draggable Filter4"]
 [editable path="Draggable Filter5"]
+[editable path="Draggable Filter"]

--- a/Scenes/multiSink.tscn
+++ b/Scenes/multiSink.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=24 format=3 uid="uid://drhixkbg1n4sa"]
+[gd_scene load_steps=21 format=3 uid="uid://drhixkbg1n4sa"]
 
 [ext_resource type="Script" path="res://Scripts/multi_sink.gd" id="1_x4ymc"]
 [ext_resource type="Texture2D" uid="uid://crbbdu26tlg2k" path="res://2D Assets/background.png" id="1_x35ji"]
@@ -11,11 +11,11 @@
 [ext_resource type="Texture2D" uid="uid://dlnjpu1sbekqf" path="res://2D Assets/conveyer texture.png" id="8_wibrt"]
 [ext_resource type="Script" path="res://Scripts/conveyor.gd" id="9_s7axg"]
 [ext_resource type="Script" path="res://Scripts/draggable_filter.gd" id="10_oh2sn"]
-[ext_resource type="Texture2D" uid="uid://cs6prh1shv4bh" path="res://2D Assets/funnels/blueFunnel.png" id="11_mf5ap"]
-[ext_resource type="Texture2D" uid="uid://bpkn0kgyf867u" path="res://2D Assets/funnels/redFunnel.png" id="12_2vchf"]
 [ext_resource type="Texture2D" uid="uid://dreyprum5m05y" path="res://2D Assets/funnels/greenFunnel.png" id="13_fp6xy"]
+[ext_resource type="PackedScene" uid="uid://bquha0225l1ju" path="res://Scenes/draggable_filter_blue.tscn" id="13_w7pdg"]
 [ext_resource type="Script" path="res://Scripts/multi_sink_start.gd" id="15_2dg66"]
 [ext_resource type="Script" path="res://Scripts/restart.gd" id="15_hhntj"]
+[ext_resource type="PackedScene" uid="uid://bi4a6dl8q6rnj" path="res://Scenes/draggable_filter_red.tscn" id="16_nxrac"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b2e8j"]
 content_margin_top = 14.0
@@ -35,27 +35,8 @@ corner_radius_top_right = 7
 corner_radius_bottom_right = 7
 corner_radius_bottom_left = 7
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_sjavo"]
-size = Vector2(160, 185)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wwsvk"]
-content_margin_top = 8.0
-bg_color = Color(0.235294, 0.517647, 0.772549, 1)
-corner_radius_top_left = 7
-corner_radius_top_right = 7
-corner_radius_bottom_right = 7
-corner_radius_bottom_left = 7
-
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_o1j7t"]
 size = Vector2(160, 185)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qk3t7"]
-content_margin_top = 10.0
-bg_color = Color(0.988235, 0.392157, 0.392157, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4cu8a"]
 content_margin_top = 8.0
@@ -141,56 +122,12 @@ scale = Vector2(0.6, 0.6)
 texture = ExtResource("7_ddj2a")
 boxType = "Green"
 
-[node name="Draggable Filter" type="Area2D" parent="."]
-position = Vector2(78, 89)
+[node name="Draggable Filter4" parent="." instance=ExtResource("13_w7pdg")]
+position = Vector2(79, 91)
 scale = Vector2(0.7, 0.7)
-script = ExtResource("10_oh2sn")
-filterColor = "Blue"
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Draggable Filter"]
-position = Vector2(0.333374, -0.5)
+[node name="CollisionShape2D" parent="Draggable Filter4" index="0"]
 scale = Vector2(0.6, 0.6)
-shape = SubResource("RectangleShape2D_sjavo")
-
-[node name="Sprite2D" type="Sprite2D" parent="Draggable Filter"]
-position = Vector2(0.333374, 0.333313)
-texture = ExtResource("11_mf5ap")
-
-[node name="hoverlabel" type="RichTextLabel" parent="Draggable Filter"]
-visible = false
-offset_left = 84.0
-offset_top = -81.0
-offset_right = 211.0
-offset_bottom = -41.0
-theme_override_styles/normal = SubResource("StyleBoxFlat_wwsvk")
-bbcode_enabled = true
-text = "[center][b]FILTER B
-"
-
-[node name="Draggable Filter2" type="Area2D" parent="."]
-position = Vector2(78, 219)
-scale = Vector2(0.7, 0.7)
-script = ExtResource("10_oh2sn")
-filterColor = "Red"
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Draggable Filter2"]
-position = Vector2(0.333374, -0.5)
-scale = Vector2(0.6, 0.6)
-shape = SubResource("RectangleShape2D_o1j7t")
-
-[node name="Sprite2D" type="Sprite2D" parent="Draggable Filter2"]
-position = Vector2(0.333374, 0.333313)
-texture = ExtResource("12_2vchf")
-
-[node name="hoverlabel" type="RichTextLabel" parent="Draggable Filter2"]
-visible = false
-offset_left = 86.0
-offset_top = -64.0
-offset_right = 196.0
-offset_bottom = -19.0
-theme_override_styles/normal = SubResource("StyleBoxFlat_qk3t7")
-bbcode_enabled = true
-text = "[center] [b]FILTER R"
 
 [node name="Draggable Filter3" type="Area2D" parent="."]
 position = Vector2(78, 349)
@@ -269,14 +206,14 @@ theme_override_font_sizes/normal_font_size = 50
 bbcode_enabled = true
 text = "[center]RESTART"
 
-[connection signal="area_entered" from="Draggable Filter" to="Draggable Filter" method="_on_area_entered"]
-[connection signal="body_shape_exited" from="Draggable Filter" to="Draggable Filter" method="_on_body_shape_exited"]
-[connection signal="mouse_entered" from="Draggable Filter" to="Draggable Filter" method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="Draggable Filter" to="Draggable Filter" method="_on_mouse_exited"]
-[connection signal="area_entered" from="Draggable Filter2" to="Draggable Filter2" method="_on_area_entered"]
-[connection signal="body_shape_exited" from="Draggable Filter2" to="Draggable Filter2" method="_on_body_shape_exited"]
-[connection signal="mouse_entered" from="Draggable Filter2" to="Draggable Filter2" method="_on_mouse_entered"]
-[connection signal="mouse_exited" from="Draggable Filter2" to="Draggable Filter2" method="_on_mouse_exited"]
+[node name="Draggable Filter5" parent="." instance=ExtResource("16_nxrac")]
+position = Vector2(78, 216)
+scale = Vector2(0.7, 0.7)
+filterColor = "Red"
+
+[node name="CollisionShape2D" parent="Draggable Filter5" index="0"]
+scale = Vector2(0.6, 0.6)
+
 [connection signal="area_entered" from="Draggable Filter3" to="Draggable Filter3" method="_on_area_entered"]
 [connection signal="body_shape_exited" from="Draggable Filter3" to="Draggable Filter3" method="_on_body_shape_exited"]
 [connection signal="mouse_entered" from="Draggable Filter3" to="Draggable Filter3" method="_on_mouse_entered"]
@@ -287,3 +224,5 @@ text = "[center]RESTART"
 
 [editable path="SinkR"]
 [editable path="SinkG"]
+[editable path="Draggable Filter4"]
+[editable path="Draggable Filter5"]

--- a/Scripts/event_box.gd
+++ b/Scripts/event_box.gd
@@ -45,3 +45,12 @@ func on_click():
 	print("hi")
 	ConveyerController.selected = self
 	AudioManager.play_click_start()
+
+
+func _on_area_2d_mouse_entered():
+	$hoverlabel.show() # Replace with function body.
+
+
+
+func _on_area_2d_mouse_exited():
+	$hoverlabel.hide() # Replace with function body.


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

-This PR replaces the local Filters in different scenes with the saved scene of the Draggable Filter.

-Additionally, there is a small snippet of code in this PR that fixes back the hover label for events, which appears to have been unintentionally removed in [PR #68](https://github.com/knative-extensions/educational-game/pull/68), so this PR also includes that 2 line small fix.

Related to #101 

<!-- Please include the 'why' behind your changes if no issue exists -->
This PR replaces the local Filters in different scenes with the saved scene of the Draggable Filter, so when we need to make a change in Filters, we can directly change the Filter properties (like sprite changes, etc.) from the saved scene, and we don't need to change every filter separately in the scene.