### PR TITLE
refactor: add consistent game object refactor plan

### DIFF
--- a/docs/refactor-game-objects.md
+++ b/docs/refactor-game-objects.md
@@ -1,0 +1,8 @@
+## Refactor Plan: Consistent Game Object Setup
+
+### Changes:
+- [ ] Convert Box objects to inherited scene
+- [ ] Convert Sink objects to inherited scene
+- [ ] Convert Filter objects to inherited scene
+- [ ] Remove all local copies from level scenes
+- [ ] Update all references in scripts


### PR DESCRIPTION
Related to #101

Adds refactor plan document for consistent game object setup across
all levels.

Current problem:
Game objects are duplicated locally in each level scene. This makes
it difficult to make global changes to object properties.

Proposed solution:
Convert all game objects to use inherited scenes (prefabs) so changes
are automatically propagated across all levels.

Refactor plan included in `docs/refactor-game-objects.md`
