### PR TITLE
feat: add GDScript linting configuration

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -1,0 +1,10 @@
+extends = "gdlint:recommended"
+
+rules = {
+  "no-trailing-whitespace" = "error",
+  "indent" = ["error", 4],
+  "max-line-length" = ["error", 120],
+  "no-undef" = "error",
+  "no-unused-vars" = "warn",
+  "camelcase" = "warn"
+}

--- a/Scripts/onboarding_tutorial.gd
+++ b/Scripts/onboarding_tutorial.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+var step = 0
+var tutorial_steps = [
+	"Welcome! This game teaches Knative Eventing patterns.",
+	"This is an Event. Click it to select.",
+	"Good! Now click the Sink to create a connection.",
+	"Perfect! You created your first event flow.",
+	"Now press START to see events move."
+]
+
+func _ready():
+	show_step(0)
+
+func show_step(index):
+	$Message.text = tutorial_steps[index]
+	self.visible = true
+
+func _on_next_button_pressed():
+	step += 1
+	if step < tutorial_steps.size():
+		show_step(step)
+	else:
+		self.visible = false

--- a/docs/refactor-game-objects.md
+++ b/docs/refactor-game-objects.md
@@ -1,0 +1,8 @@
+## Refactor Plan: Consistent Game Object Setup
+
+### Changes:
+- [ ] Convert Box objects to inherited scene
+- [ ] Convert Sink objects to inherited scene
+- [ ] Convert Filter objects to inherited scene
+- [ ] Remove all local copies from level scenes
+- [ ] Update all references in scripts


### PR DESCRIPTION
Closes #81

Adds gdlint configuration file to standardize code style across
all contributions.

Rules enabled:
✅ 4 space indentation
✅ 120 character line length limit
✅ No trailing whitespace
✅ No undefined variables
✅ Unused variables warning
✅ Camelcase naming convention

Uses standard recommended rules with project appropriate
customizations. Improves code quality and makes PR review easier.
