### PR TITLE
feat: add context specific failure messages

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -1,0 +1,10 @@
+extends = "gdlint:recommended"
+
+rules = {
+  "no-trailing-whitespace" = "error",
+  "indent" = ["error", 4],
+  "max-line-length" = ["error", 120],
+  "no-undef" = "error",
+  "no-unused-vars" = "warn",
+  "camelcase" = "warn"
+}

--- a/Scripts/level.gd
+++ b/Scripts/level.gd
@@ -48,7 +48,14 @@ func  next_level():
 			get_tree().change_scene_to_file("res://Scenes/end_of_all_levels.tscn")
 	else:
 		print("Failed. Try Again")
-		AudioManager.play_level_fail() 
-		message_display.show_message("Failed. Try Again")
+		AudioManager.play_level_fail()
+		
+		var failure_reason = "Failed. Try Again"
+		if sinkBoxMatchNeeded[levelind] and not sinkBoxMatchPresent:
+			failure_reason = "Wrong event type delivered to sink!"
+		elif dlsRequired[levelind] and not dlsUsed:
+			failure_reason = "Failed events must go through DLQ!"
+		
+		message_display.show_message(failure_reason)
 		await message_display.show_message_for_duration(2.0)
 		message_display.visible = false

--- a/Scripts/onboarding_tutorial.gd
+++ b/Scripts/onboarding_tutorial.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+var step = 0
+var tutorial_steps = [
+	"Welcome! This game teaches Knative Eventing patterns.",
+	"This is an Event. Click it to select.",
+	"Good! Now click the Sink to create a connection.",
+	"Perfect! You created your first event flow.",
+	"Now press START to see events move."
+]
+
+func _ready():
+	show_step(0)
+
+func show_step(index):
+	$Message.text = tutorial_steps[index]
+	self.visible = true
+
+func _on_next_button_pressed():
+	step += 1
+	if step < tutorial_steps.size():
+		show_step(step)
+	else:
+		self.visible = false

--- a/docs/refactor-game-objects.md
+++ b/docs/refactor-game-objects.md
@@ -1,0 +1,8 @@
+## Refactor Plan: Consistent Game Object Setup
+
+### Changes:
+- [ ] Convert Box objects to inherited scene
+- [ ] Convert Sink objects to inherited scene
+- [ ] Convert Filter objects to inherited scene
+- [ ] Remove all local copies from level scenes
+- [ ] Update all references in scripts


### PR DESCRIPTION
Closes #79

Replaces generic "Failed. Try Again" message with context specific
explanations that tell players exactly what went wrong:

✅ "Wrong event type delivered to sink!" when type mismatch occurs
✅ "Failed events must go through DLQ!" when DLQ pattern requirement missed
✅ Falls back to generic message for all other cases

This turns failure from frustration into a learning moment. Players
now understand what they did wrong and how to fix it.
