### PR TITLE
feat: add display setting for the game

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,11 @@ ConveyerController="*res://Scripts/ConveyerController.gd"
 Level="*res://Scripts/level.gd"
 AudioManager="*res://Scripts/AudioManager.gd"
 
+[display]
+
+window/size/mode=3
+window/stretch/mode="canvas_items"
+
 [input]
 
 click={


### PR DESCRIPTION
The game's display size mode is set to "Fullscreen", and the stretch mode is set to "canvas_item", which makes it suitable for the web version of the game.
