### PR TITLE
fix: reinitialise ConveyerController before scene reload in restart.gd

### DIFF
--- a/Scripts/restart.gd
+++ b/Scripts/restart.gd
@@ -12,8 +12,13 @@ func _process(delta: float) -> void:
 
 func _on_button_pressed() -> void:
 	print("restart clicked")
-	#if not Level.nextLevel:
-		#Level.levelind-=1
+	# Reinitialise ConveyerController BEFORE reloading the scene so that
+	# autoload state is clean when the new scene tree is built.  Previously
+	# ConveyerController.initialise() was called after reload_current_scene(),
+	# which meant it executed in the context of the freshly-loaded scene and
+	# could race with _ready() callbacks that read ConveyerController fields
+	# (e.g. setup() appending to conveyer[]).  Calling it first guarantees a
+	# blank slate for the incoming scene.
+	ConveyerController.initialise()
 	Level.initialise()
 	get_tree().reload_current_scene()
-	ConveyerController.initialise()


### PR DESCRIPTION
Description
Fixes a race condition in restart.gd where ConveyerController.initialise() was called after get_tree().reload_current_scene(), leaving stale conveyor state (event lists, conveyor index, destination arrays) visible to the freshly-loaded scene's _ready() callbacks.

Motivation
Godot autoloads survive scene reloads. When the player pressed the Restart button, reload_current_scene() triggered conveyor.gd's _ready() → ConveyerController.setup() before ConveyerController.initialise() had been called. The result was:

Events from the previous run persisted in ConveyerController.events[].
conveyerInd was non-zero on the first frame of the restarted level.
Ghost conveyor lines (already-drawn Line2D points) appeared immediately on restart.
The same principle is already documented inside level.gd with the comment:

# CRITICAL FIX: Initialize BEFORE changing scene, not after!

This PR applies that same pattern consistently to the restart path.

signed 0ff: saiashok103@gmail.com